### PR TITLE
feat: show commit message in commit-wise review panel

### DIFF
--- a/lua/octo/model/pull-request.lua
+++ b/lua/octo/model/pull-request.lua
@@ -118,6 +118,7 @@ function PullRequest:get_commit_changed_files(rev, callback)
         local FileEntry = require("octo.reviews.file-entry").FileEntry
         local results = vim.fn.json_decode(output)
         local files = {}
+        local commit = results.commit or {}
         if results.files then
           for _, result in ipairs(results.files) do
             local entry = FileEntry:new {
@@ -134,7 +135,7 @@ function PullRequest:get_commit_changed_files(rev, callback)
             }
             table.insert(files, entry)
           end
-          callback(files)
+          callback(files, commit)
         end
       end
     end,

--- a/lua/octo/reviews/file-panel.lua
+++ b/lua/octo/reviews/file-panel.lua
@@ -379,9 +379,6 @@ function FilePanel:render()
     line_idx = line_idx + 1
   end
 
-  local right = current_review.layout.right
-  local left = current_review.layout.left
-  local extra_info = { left:abbrev() .. ".." .. right:abbrev() }
   table.insert(lines, "")
   line_idx = line_idx + 1
 
@@ -389,6 +386,19 @@ function FilePanel:render()
   add_hl("DiffviewFilePanelTitle", line_idx, 0, #s)
   table.insert(lines, s)
   line_idx = line_idx + 1
+
+  local message = current_review.layout.message or ""
+  if message ~= "" then
+    s = message
+    add_hl("OctoFilePanelMessage", line_idx, 0, #s)
+    table.insert(lines, s)
+    line_idx = line_idx + 1
+    return
+  end
+
+  local right = current_review.layout.right
+  local left = current_review.layout.left
+  local extra_info = { left:abbrev() .. ".." .. right:abbrev() }
 
   for _, arg in ipairs(extra_info) do
     s = arg

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -111,11 +111,13 @@ function Review:focus_commit(right, left)
     files = {},
   }
   self.layout:open(self)
-  local cb = function(files)
+  local cb = function(files, commit)
     -- pre-fetch the first file
     if #files > 0 then
       files[1]:fetch()
     end
+    -- FIXME: not ideally placed here
+    self.layout.message = commit and commit.message or ""
     self.layout.files = files
     self.layout:update_files()
   end

--- a/lua/octo/reviews/layout.lua
+++ b/lua/octo/reviews/layout.lua
@@ -25,6 +25,7 @@ local win_reset_opts = {
 ---@field files FileEntry[]
 ---@field file_idx integer
 ---@field ready boolean
+---@field message string
 local Layout = {}
 Layout.__index = Layout
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

When reviewing each commits, the picker currently shows the commit message. However, I'd prefer to display it on each commit's detail screen for a quick reminder of the changes.

When possible, the commit message should appear instead of the commit hash, specifically during commit-wise reviews.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it


### Describe how to verify it

![image](https://github.com/user-attachments/assets/50b9786d-91b0-49c8-9355-7beb2b774587)

### Special notes for reviews

